### PR TITLE
Simplify enums and remove references to bufferOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,6 @@ EspressoLogcat.getLogcatLikeLineData(pid = 1234)
 // adb logcat -d -s -pid=1234
 ```
 
-_**bufferOptions**_: array of BufferOptions, equal to passing in a buffer variable via `-b`
-```kotlin
-EspressoLogcat.getLogcatLikeLineData(bufferOptions = arrayOf(BufferOptions.DEFAULT))
-// adb logcat -d -s -b default
-```
-
 _**options**_: vararg strings to pass in any other logcat options
 (_Note_: Because the core functionality of espressoLogcat involves parsing string responses, it is very possible that adding
   extra options that affect the logcat output will cause exceptions.)

--- a/src/main/kotlin/espressoLogcat/Enums.kt
+++ b/src/main/kotlin/espressoLogcat/Enums.kt
@@ -2,16 +2,16 @@ package espressoLogcat
 
 /**
  * Priority, also known as level, to be used when querying logcat
- * `abbr` is the first character of the string
+ * `levelFlag` is the first character of the string, which maps to a priority appended to a `tag` string during query
  */
-enum class Priority(val abbr: String) {
-    VERBOSE(abbr = "V"),
-    DEBUG(abbr = "D"),
-    INFO(abbr = "I"),
-    WARNING(abbr = "W"),
-    ERROR(abbr = "E"),
-    FATAL(abbr = "F"),
-    SILENT(abbr = "S")
+enum class Priority(internal val levelFlag: String) {
+    VERBOSE(levelFlag = "V"),
+    DEBUG(levelFlag = "D"),
+    INFO(levelFlag = "I"),
+    WARNING(levelFlag = "W"),
+    ERROR(levelFlag = "E"),
+    FATAL(levelFlag = "F"),
+    SILENT(levelFlag = "S")
 }
 
 /**

--- a/src/main/kotlin/espressoLogcat/Enums.kt
+++ b/src/main/kotlin/espressoLogcat/Enums.kt
@@ -1,15 +1,23 @@
 package espressoLogcat
 
-enum class Priority {
-    VERBOSE,
-    DEBUG,
-    INFO,
-    WARNING,
-    ERROR,
-    FATAL,
-    SILENT
+/**
+ * Priority, also known as level, to be used when querying logcat
+ * `abbr` is the first character of the string
+ */
+enum class Priority(val abbr: String) {
+    VERBOSE(abbr = "V"),
+    DEBUG(abbr = "D"),
+    INFO(abbr = "I"),
+    WARNING(abbr = "W"),
+    ERROR(abbr = "E"),
+    FATAL(abbr = "F"),
+    SILENT(abbr = "S")
 }
 
+/**
+ * Various output formats. These are equivalent to passing in `-v {OutputFormat}` when querying logcat.
+ * However, EspressoLogcat only queries logcat with `threadtime` and then formats the response to match
+ */
 enum class OutputFormat {
     BRIEF,
     LONG,
@@ -20,22 +28,3 @@ enum class OutputFormat {
     THREADTIME,
     TIME
 }
-
-enum class BufferOptions {
-    RADIO,
-    EVENTS,
-    MAIN,
-    SYSTEM,
-    CRASH,
-    ALL,
-    DEFAULT
-}
-
-data class LineData(
-    val date: String,
-    val pid: String,
-    val tid: String,
-    val level: String,
-    val tag: String,
-    val coreData: String
-)

--- a/src/main/kotlin/espressoLogcat/EspressoLogcat.kt
+++ b/src/main/kotlin/espressoLogcat/EspressoLogcat.kt
@@ -17,7 +17,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -31,7 +30,6 @@ class EspressoLogcat {
                 tTime = tTime,
                 pid = pid,
                 outputFormat = BRIEF,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -46,7 +44,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -60,7 +57,6 @@ class EspressoLogcat {
                 tTime = tTime,
                 pid = pid,
                 outputFormat = LONG,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -75,7 +71,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -89,7 +84,6 @@ class EspressoLogcat {
                 tTime = tTime,
                 pid = pid,
                 outputFormat = PROCESS,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -104,7 +98,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -118,7 +111,6 @@ class EspressoLogcat {
                 tTime = tTime,
                 pid = pid,
                 outputFormat = RAW,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -133,7 +125,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -147,7 +138,6 @@ class EspressoLogcat {
                 tTime = tTime,
                 pid = pid,
                 outputFormat = TAG,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -162,7 +152,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -176,7 +165,6 @@ class EspressoLogcat {
                 tTime = tTime,
                 pid = pid,
                 outputFormat = THREAD,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -191,7 +179,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -204,7 +191,6 @@ class EspressoLogcat {
                 tCount = tCount,
                 tTime = tTime,
                 pid = pid,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -219,8 +205,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<String> {
             return EspressoLogcat().getLogCat(
@@ -234,7 +218,6 @@ class EspressoLogcat {
                 tTime = tTime,
                 pid = pid,
                 outputFormat = TIME,
-                bufferOptions = bufferOptions,
                 options = options
             )
         }
@@ -253,7 +236,6 @@ class EspressoLogcat {
          * @param tTime string for only printing the lines since the provided time, accompanies the `-t` flag.
          *        exclusive with `tCount`
          * @param pid allows filtering by a specific pid, accompanies the `--pid` flag.
-         * @param bufferOptions an array of buffer options for the logcat, each accompanies the `-b` flag.
          * @param options an additional string array to include any logcat options not provided for by the other parameters.
          */
         fun getLogcatLikeLineData(
@@ -265,7 +247,6 @@ class EspressoLogcat {
             tCount: Int? = null,
             tTime: String? = null,
             pid: Int? = null,
-            bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
             vararg options: String? = arrayOf()
         ): MutableCollection<LineData> {
             // uses the above parameters to construct a string array
@@ -273,7 +254,6 @@ class EspressoLogcat {
                 tCount = tCount,
                 tTime = tTime,
                 pid = pid,
-                buffer = bufferOptions
             )
             // formatted tag:priority string array
             val tagPriority = LogcatOptions().getTagPriority(tag = tag, priority = priority)
@@ -330,16 +310,9 @@ class EspressoLogcat {
             }
         }
 
-        fun clearLogcat(buffer: Array<BufferOptions> = arrayOf()) {
+        fun clearLogcat() {
             try {
-                val bufferOptions = mutableListOf<String>()
-                if (buffer.isNotEmpty()) {
-                    for (option in buffer) {
-                        bufferOptions.add("-b")
-                        bufferOptions.add(option.toString().toLowerCase())
-                    }
-                }
-                Runtime.getRuntime().exec(arrayOf("logcat", *bufferOptions.toTypedArray(), "-c"))
+                Runtime.getRuntime().exec(arrayOf("logcat", "-c"))
             } catch (exception: Exception) {
                 throw exception
             }
@@ -356,7 +329,6 @@ class EspressoLogcat {
         tCount: Int? = null,
         tTime: String? = null,
         pid: Int? = null,
-        bufferOptions: Array<BufferOptions> = arrayOf(BufferOptions.DEFAULT),
         outputFormat: OutputFormat = THREADTIME,
         vararg options: String? = arrayOf()
     ): MutableCollection<String> {
@@ -369,7 +341,6 @@ class EspressoLogcat {
             tCount = tCount,
             tTime = tTime,
             pid = pid,
-            bufferOptions = bufferOptions,
             options = options
         )
         return Formatters().formatLineData(lineDataValues, outputFormat, filename = filename)

--- a/src/main/kotlin/espressoLogcat/LineData.kt
+++ b/src/main/kotlin/espressoLogcat/LineData.kt
@@ -1,0 +1,10 @@
+package espressoLogcat
+
+data class LineData(
+    val date: String,
+    val pid: String,
+    val tid: String,
+    val level: String,
+    val tag: String,
+    val coreData: String
+)

--- a/src/main/kotlin/espressoLogcat/LogcatOptions.kt
+++ b/src/main/kotlin/espressoLogcat/LogcatOptions.kt
@@ -1,13 +1,10 @@
 package espressoLogcat
 
-import espressoLogcat.BufferOptions.*
-
 class LogcatOptions {
     fun getOptions(
         tCount: Int? = null,
         tTime: String? = null,
         pid: Int? = null,
-        vararg buffer: BufferOptions = arrayOf(DEFAULT)
     ): Array<String> {
         val options = mutableListOf<String>()
 
@@ -25,30 +22,18 @@ class LogcatOptions {
             options.add("--pid=$pid")
         }
 
-        // add buffer options
-        for (option in buffer) {
-            options.add("-b")
-            options.add(option.toString().toLowerCase())
-        }
-
         return options.toTypedArray()
     }
 
     fun getTagPriority(tag: String = "*", priority: Priority? = null): Array<String> {
-        val tagPriority = if (priority == null) {
-            if (tag == "*") {
-                ""
+        return if (priority == null) {
+            if (tag.startsWith("*")) {
+                arrayOf("")
             } else {
-                tag
+                arrayOf(tag)
             }
         } else {
-            "$tag:${priority.toString()[0]}"
-        }
-
-        return if (tagPriority.startsWith("*")) {
-            arrayOf(tagPriority)
-        } else {
-            arrayOf(tagPriority, "-s")
+            arrayOf("$tag:${priority.abbr}", "-s")
         }
     }
 }

--- a/src/main/kotlin/espressoLogcat/LogcatOptions.kt
+++ b/src/main/kotlin/espressoLogcat/LogcatOptions.kt
@@ -33,7 +33,7 @@ class LogcatOptions {
                 arrayOf(tag)
             }
         } else {
-            arrayOf("$tag:${priority.abbr}", "-s")
+            arrayOf("$tag:${priority.levelFlag}", "-s")
         }
     }
 }


### PR DESCRIPTION
Fixes #7 

- Since I was already in `Enums`, just removed bufferOptions and all references. Complete overhaul of removing/revamping unused/unneeded options will come in a later PR.
- Moved data class into it's own file
- Simplified the function that uses `Priority.abbr`